### PR TITLE
Laboratoire 3

### DIFF
--- a/qprod_test.jl
+++ b/qprod_test.jl
@@ -1,0 +1,46 @@
+"""
+    onehot(T, m, k)
+
+Construit un vecteur de taille `m` d'éléments de type `T` composé de zéros et d'un 1 à l'indice `k`.
+Si `T` est omis, le type Float64 est utilisé.
+"""
+function onehot(T, m, k)
+  @assert 1 ≤ k ≤ m
+  x = zeros(T, m)
+  x[k] = 1
+  x
+end
+
+function check_Q(A, Q)
+  m, n = size(A)
+  T = eltype(A)
+  Qjulia = hcat([Q * onehot(T, m, k) for k = 1:m]...)
+  err_Q = norm(hcat([Qprod_simple!(A, onehot(T, m, k)) for k = 1:m]...) - Qjulia)
+  println("erreur sur Q : ", err_Q)
+end
+
+function check_QR(A)
+  m, n = size(A)
+  Q, R = qr(A)
+  B = copy(A)
+  myqr_opti!(B)
+  check_Q(B, Q)
+  err_R = norm(UpperTriangular(B[1:n, 1:n] - R)) / norm(UpperTriangular(R))
+  println("erreur sur R : ", err_R)
+end
+
+function check_Qconj(A, Q)
+  m, n = size(A)
+  T = eltype(A)
+  Qjulia = hcat([Q' * onehot(T, m, k) for k = 1:m]...)
+  err_Q = norm(hcat([Qprod_conjugue!(A, onehot(T, m, k)) for k = 1:m]...) - Qjulia)
+  println("erreur sur Q : ", err_Q)
+end
+
+m, n = 10, 4
+A = rand(10, 4)
+Q, R = qr(A)
+myqr_opti!(A)
+
+check_QR(A)
+check_Qconj(A, Q)

--- a/qr_simple_evaluation.jl
+++ b/qr_simple_evaluation.jl
@@ -1,0 +1,47 @@
+using LinearAlgebra
+
+function my_sign(x::Number)
+    if x == zero(x)
+      return one(x)
+    else
+      return sign(x)
+    end
+end
+
+"""
+    myqr_simple(A)
+
+Écrase `A` par le résultat de la factorisation QR compacte de Householder.
+"""
+function myqr_simple!(A)
+  m, n = size(A)
+  @assert m ≥ n
+  for j = 1:n
+    vj = A[j:m,j]
+    σj = my_sign(vj[1])
+    vj_norm = norm(vj)
+    vj[1] += σj * vj_norm
+    vj ./= vj[1]
+    δj = vj'vj
+
+    A[j:m,j:n] -= 2 * vj * (vj' * A[j:m,j:n]) / δj
+    A[j+1:m,j] = vj[2:end]
+  end
+  A
+end 
+
+"""
+    Qprod_simple!(A, x)
+
+Écrase `x` par le résultat du produit Q * x, où Q est le facteur unitaire de la factorisation QR compacte de Householder.
+On suppose que `A` contient déjà le résultat de cette factorisation QR compacte.
+"""
+function Qprod_simple!(A, x)
+  m, n = size(A)
+  for j = n:-1:1
+    uj = [1 ; A[j+1:m, j]]
+    δj = uj'uj
+    x[j:m] -= 2*uj*(uj'x[j:m])/δj
+  end
+  x
+end

--- a/rapport.qmd
+++ b/rapport.qmd
@@ -2,8 +2,8 @@
 title: "Rapport de laboratoire 3"
 subtitle: "MTH8211"
 author:
-  - name: Votre nom
-    email: votre.adresse@polymtl.ca
+  - name: Hortense Beaudoin
+    email: hortense.beaudoin@polymtl.ca
     affiliation:
       - name: Polytechnique Montréal
 format:
@@ -41,28 +41,111 @@ Ce rapport doit contenir des comparaisons entre l'implémentation de base, votre
 
 ```{julia}
 #| output: false
+Pkg.add("BenchmarkTools")
+using BenchmarkTools
 ```
 
 2. mesurer le temps d'exécution et les allocations des fonctions `myqr_simple!()` et `Qprod_simple!()` sur un exemple de taille $500 \times 100$ et les comparer à un appel direct à la factorisation QR de LAPACK ;
 
 ```{julia}
-# ...
+{{< include qr_simple_evaluation.jl >}}
+```
+
+```{julia}
+A = rand(Float64,(500,100))
+x = rand(Float64,500)
+@benchmark myqr_simple!(mat) setup=(mat=deepcopy($A))
+```
+
+```{julia}
+@benchmark LAPACK.geqrf!(mat) setup=(mat=deepcopy($A))
+```
+
+```{julia}
+@benchmark Qprod_simple!($A, $x)
 ```
 
 3. éliminer autant que possible les allocations (il est possible d'obtenir zéro allocations) ;
 
 ```{julia}
-# ...
+function myqr_opti!(A)
+  m, n = size(A)
+  @assert m ≥ n
+  v = similar(A, m)
+
+  for j = 1:n
+    v[j:m] .= @view A[j:m,j]
+    vj = @view v[j:m]
+
+    vj_norm = norm(vj)
+    vj[1] += my_sign(vj[1]) * vj_norm      
+    vj ./= vj[1]
+
+    Aj = @view A[j:m, j:n]
+    Aj .-= (2/dot(vj,vj)) .* (vj .* (vj' * Aj))
+    
+    A[j+1:m,j] .= vj[2:end]
+  end
+  A
+end 
+```
+
+
+```{julia}
+@benchmark myqr_opti!(mat) setup=(mat=deepcopy($A))
 ```
 
 4. implémenter le produit avec $Q^*$ sans allocations et valider qu'il est correct ;
 
+Pour l'implémentation sans allocations, j'ai décomposé algébriquement les opérations à faire et j'ai implémenté le tout avec des views et des opérations *element-wise*. Le principe est le même que pour le produit avec $Q$, mais on parcoure $A$ dans l'autre sens.
 ```{julia}
-# ...
+function Qprod_conjugue!(A, x)
+  m, n = size(A)
+
+  for j = 1:n
+    x1 = x[j]
+    xj = @view x[j+1:m]
+    uj = @view A[j+1:m,j] 
+
+    δj = 1 + dot(uj,uj)
+    βj = dot(uj,xj)
+
+    x[j] -= (2* (x[j] + βj)) / δj
+    xj .-= (2 .* (x1 .* uj .+ βj .* uj)) ./ δj
+  end
+
+  x
+end
+```
+
+```{julia}
+@benchmark Qprod_conjugue!($A, $x)
+```
+
+```{julia}
+{{< include qprod_test.jl >}}
 ```
 
 5. valider que la factorisation et les produits avec $Q$ et $Q^*$ fonctionnent correctement quand $A$ est complexe et quand $A$ contient des entrées de type `BigFloat`.
 
 ```{julia}
-# ...
+B = rand(BigFloat,10,4)
+Q, R = qr(B)
+myqr_simple!(B)
+
+check_Q(B, Q)
+check_QR(B)
+check_Qconj(B, Q)
 ```
+
+```{julia}
+C = rand(ComplexF64,10,4)
+Q, R = qr(C)
+myqr_simple!(C)
+
+check_Q(C, Q)
+check_QR(C)
+check_Qconj(C, Q)
+```
+
+L'erreur sur le cas complexe se produit également pour l'implémentation de base vue en classe. Je ne suis pas parvenue à trouver la source. Quelques hypothèses: la gestion du signe avec la fonction my_sign, la normalisation, le résultat de la fonction dot. Tout devrait fonctionner aussi avec des complexes et je m'explique donc mal d'où peut venir l'erreur, sinon d'une potentielle instabilité numérique liée à la manipulation des complexes. 


### PR DESCRIPTION
# Optimisation de Householder

Je n'ai pas réussi à complètement éliminer le nombre d'allocations. Probablement que j'aurais du faire une réduction/un travail algébrique en parallèle pour y parvenir. Comme première version optimisée, j'ai malgré tout réussi à réduire le nombre d'allocations à environ le nombre de ligne de la matrice. J'ai principalement utilisé des *views* et une déclaration en avance des toutes les valeurs scalaires. 

# Produit avec $Q^*$

Plutôt que de multiplier à partir de la dernière colonne, on commence à partir de la première. Le reste de l'implémentation est la même que celle pour le produit avec $Q$. Pour réduire le nombre d'allocation, j'ai algébriquement décomposé les produits, pour éviter de devoir construire les vecteurs $u$ avec le premier élément 1. Comme pour la décomposition, j'ai utilisé les *views*. 

# Entrées complexes et BigFloat

L'implémentation fonctionne bien avec les BigFloat, mais pas avec les nombres complexes. Je m'explique mal pourquoi; je pense qu'il y a sûrement quelque chose à voir avec l'application du signe et/ou la normalisation des vecteurs. Je ne pense pas que mes modifications soient à la source du problème, puisque les fonctions de base du laboratoire ne fonctionnent pas non plus. Je serai curieuse d'en discuter en classe ce jeudi ! 